### PR TITLE
Fix IE9-11 "Unexpected call to method or property access." for `path.getTotalLength()` after `path.setPathData([])`

### DIFF
--- a/path-data-polyfill.js
+++ b/path-data-polyfill.js
@@ -965,7 +965,7 @@ if (!SVGPathElement.prototype.getPathData || !SVGPathElement.prototype.setPathDa
 
     SVGPathElement.prototype.setPathData = function(pathData) {
       if (pathData.length === 0) {
-        this.removeAttribute("d");
+        this.setAttribute("d", "");
       }
       else {
         var d = "";


### PR DESCRIPTION
With IE9-11 +? when the attribute `d` is removed an error "Unexpected call to method or property access." will throw for the next `path.getTotalLength()` call.

See mbostock/d3#1737
