### PR TITLE
Add Typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,10 @@
   "author": "Jarosław Foksa",
   "license": "MIT",
   "bugs": "https://github.com/jarek-foksa/path-data-polyfill/issues",
-  "homepage": "https://github.com/jarek-foksa/path-data-polyfill#readme"
+  "homepage": "https://github.com/jarek-foksa/path-data-polyfill#readme",
+  "exports": {
+    ".": {
+        "types": "./types.d.ts"
+    }
+  }
 }

--- a/path-data-polyfill.ts
+++ b/path-data-polyfill.ts
@@ -1,0 +1,1 @@
+export * from './path-data-polyfill.js';

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,49 @@
+interface SVGPathElement {
+	/**
+	 * See https://github.com/jarek-foksa/path-data-polyfill
+	 *
+	 * See https://svgwg.org/specs/paths/#InterfaceSVGPathData
+	 */
+	getPathData: (settings?: SVGPathDataSettings) => Array<SVGPathSegment>;
+	/**
+	 * See https://github.com/jarek-foksa/path-data-polyfill
+	 *
+	 * See https://svgwg.org/specs/paths/#InterfaceSVGPathData
+	 */
+	setPathData: (pathData: Array<SVGPathSegment>) => void;
+}
+
+type SVGPathDataCommand =
+	| `A`
+	| `a`
+	| `B`
+	| `b`
+	| `C`
+	| `c`
+	| `H`
+	| `h`
+	| `L`
+	| `l`
+	| `M`
+	| `m`
+	| `Q`
+	| `q`
+	| `R`
+	| `r`
+	| `S`
+	| `s`
+	| `T`
+	| `t`
+	| `V`
+	| `v`
+	| `Z`
+	| `z`;
+
+interface SVGPathDataSettings {
+	normalize: boolean;
+}
+
+interface SVGPathSegment {
+	type: SVGPathDataCommand;
+	values: Array<number>;
+}


### PR DESCRIPTION
I needed types in order to use this in a Typescript project, so added them. This shouldn't require any additional maintenance on your part. Hopefully `getPathData` and `setPathData` will be added back to the standard browser library one of these days. :)

Until this is merged in, I've created a little wrapper package: https://www.npmjs.com/package/@robertakarobin/path-data-polyfill

Could instead contribute this to https://github.com/DefinitelyTyped/DefinitelyTyped if you prefer.

Thanks!