### PR TITLE
Fix exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,5 @@
   "license": "MIT",
   "bugs": "https://github.com/jarek-foksa/path-data-polyfill/issues",
   "homepage": "https://github.com/jarek-foksa/path-data-polyfill#readme",
-  "exports": {
-    ".": {
-        "types": "./types.d.ts"
-    }
-  }
+  "types": "./types.d.ts"
 }


### PR DESCRIPTION
Introduced in https://github.com/jarek-foksa/path-data-polyfill/pull/17

Oops, it seems I set up the `types` declaration in `package.json` incorrectly. Apparently the way I wrote it causes the main `.js` file to no longer be exported from the package. This should fix it. Sorry about that!